### PR TITLE
Use the original logger for each method

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ let _console = {}
 methods.forEach(method => {
   _console[method] = console[method]
   console[method] = function () {
-    _console.log.apply(
+    _console[method].apply(
       _console,
       [chalk.gray(process.pid), '|', chalk.gray(`${(process.memoryUsage().rss / 1048576).toFixed(2)}MB`), '|']
         .concat(isLabel ? decorateText[method] : [])


### PR DESCRIPTION
Use the original logger for each method, in order to get the correct output stream (stderr/stdout)